### PR TITLE
Remove FrontMatter from Markdown render, CSS Boogaloo

### DIFF
--- a/frontend/src/lib/render.ts
+++ b/frontend/src/lib/render.ts
@@ -2,7 +2,7 @@
  * @file
  * This file contains code used for rendering markdown code
  */
-import { marked } from 'marked';
+import { marked, type TokensList } from 'marked';
 import DOMPurify from 'dompurify';
 
 /**
@@ -13,7 +13,23 @@ import DOMPurify from 'dompurify';
  */
 export async function renderMarkdown(input: string, output: InnerHTML): Promise<undefined> {
 	// https://marked.js.org/#demo
-	const cleanedOutput: string = DOMPurify.sanitize(await marked.parse(input));
+
+	let rawTokens: TokensList = marked.lexer(input);
+
+	// Remove FrontMatter
+
+	rawTokens.shift();
+	let frontMatter: string = '';
+	try{
+		frontMatter = rawTokens.shift()['raw'].replace('---\n', '\n').trim();
+		// frontMatterPrint = `<details><summary>Show FrontMatter</summary><pre>` + frontMatter + `</pre></details>`;
+		// console.log(frontMatter);
+	}
+	catch {
+		console.log('No FrontMatter found!');
+	}
+
+	const cleanedOutput: string = DOMPurify.sanitize(await marked.parser(rawTokens));
 	if (DOMPurify.removed.length > 0) {
 		console.warn('Possible XSS detected, modified output: ', DOMPurify.removed);
 	}

--- a/frontend/src/lib/render.ts
+++ b/frontend/src/lib/render.ts
@@ -19,7 +19,7 @@ export async function renderMarkdown(input: string, output: InnerHTML): Promise<
 	// Remove FrontMatter
 
 	rawTokens.shift();
-	let frontMatter: string = '';
+	let _frontMatter: string = '';
 	try {
 		frontMatter = rawTokens.shift()['raw'].replace('---\n', '\n').trim();
 		// frontMatterPrint = `<details><summary>Show FrontMatter</summary><pre>` + frontMatter + `</pre></details>`;

--- a/frontend/src/lib/render.ts
+++ b/frontend/src/lib/render.ts
@@ -20,12 +20,11 @@ export async function renderMarkdown(input: string, output: InnerHTML): Promise<
 
 	rawTokens.shift();
 	let frontMatter: string = '';
-	try{
+	try {
 		frontMatter = rawTokens.shift()['raw'].replace('---\n', '\n').trim();
 		// frontMatterPrint = `<details><summary>Show FrontMatter</summary><pre>` + frontMatter + `</pre></details>`;
 		// console.log(frontMatter);
-	}
-	catch {
+	} catch {
 		console.log('No FrontMatter found!');
 	}
 

--- a/frontend/src/lib/render.ts
+++ b/frontend/src/lib/render.ts
@@ -14,7 +14,7 @@ import DOMPurify from 'dompurify';
 export async function renderMarkdown(input: string, output: InnerHTML): Promise<undefined> {
 	// https://marked.js.org/#demo
 
-	let rawTokens: TokensList = marked.lexer(input);
+	const rawTokens: TokensList = marked.lexer(input);
 
 	// Remove FrontMatter
 

--- a/frontend/src/routes/editor/+page.svelte
+++ b/frontend/src/routes/editor/+page.svelte
@@ -94,7 +94,6 @@
 			// when you first open it, so we don't need to worry about 401 or 403
 		}
 	}
-
 </script>
 
 <div style="--sidebar-width: {sidebarWidth}" class="container">

--- a/frontend/src/routes/editor/+page.svelte
+++ b/frontend/src/routes/editor/+page.svelte
@@ -94,6 +94,7 @@
 			// when you first open it, so we don't need to worry about 401 or 403
 		}
 	}
+
 </script>
 
 <div style="--sidebar-width: {sidebarWidth}" class="container">
@@ -116,9 +117,9 @@
 				/>
 			</svg>
 			<!-- Save -->
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
 			<svg
 				on:click={saveChangesHandler}
-				on:keydown={saveChangesHandler}
 				role="button"
 				tabindex="0"
 				xmlns="http://www.w3.org/2000/svg"
@@ -169,8 +170,8 @@
 	.publish:hover {
 		background-color: var(--background-0);
 		box-sizing: border-box;
-		border: 0.1rem var(--green) solid;
-		transition: all 0.1s ease;
+		border: 0.2rem var(--green) solid;
+		transition: all 0.05s ease-out;
 	}
 
 	.publish:hover > * {
@@ -189,7 +190,8 @@
 	.cancel:hover {
 		background-color: var(--background-0);
 		box-sizing: border-box;
-		transition: all 0.1s ease;
+		border: 0.2rem var(--red) solid;
+		transition: all 0.05s ease-out;
 	}
 
 	.cancel:hover > * {

--- a/frontend/src/routes/editor/Toast.svelte
+++ b/frontend/src/routes/editor/Toast.svelte
@@ -4,6 +4,7 @@
 	import { ToastType } from '$lib/toast';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import { quartOut } from 'svelte/easing';
 	//   import SuccessIcon from "./SuccessIcon.svelte";
 	//   import ErrorIcon from "./ErrorIcon.svelte";
 	//   import InfoIcon from "./InfoIcon.svelte";
@@ -15,7 +16,7 @@
 	export let dismissible = true;
 </script>
 
-<article class={type} role="alert" transition:fade>
+<article class={type} role="alert" transition:fade={{ duration: 150, easing: quartOut }}>
 	{#if type === ToastType.Success}
 		<svg
 			width="2rem"

--- a/frontend/src/routes/editor/Toasts.svelte
+++ b/frontend/src/routes/editor/Toasts.svelte
@@ -23,7 +23,8 @@
 		top: 0;
 		right: 0;
 		display: flex;
-		margin-top: 2rem;
+		margin-top: 1rem;
+		margin-right: 0.5rem;
 		flex-direction: column;
 		/* z-index: 1000; */
 	}

--- a/frontend/src/routes/editor/nav/FileNavigation.svelte
+++ b/frontend/src/routes/editor/nav/FileNavigation.svelte
@@ -83,7 +83,7 @@
 		border: none;
 		background: none;
 		color: var(--foreground-0);
-		font-size: 1rem;
+		font-size: inherit;
 		width: 98%;
 		border-radius: 5px;
 		margin-left: 1%;

--- a/frontend/src/routes/editor/nav/FileNavigation.svelte
+++ b/frontend/src/routes/editor/nav/FileNavigation.svelte
@@ -83,10 +83,12 @@
 		border: none;
 		background: none;
 		color: var(--foreground-0);
-		font-size: larger;
+		font-size: 1rem;
 		width: 98%;
 		border-radius: 5px;
 		margin-left: 1%;
+		margin-top: 0.4rem;
+		margin-bottom: 0.4rem;
 		padding-top: 0.4rem;
 		padding-bottom: 0.4rem;
 		/* overflow-x: hidden; */

--- a/frontend/src/routes/editor/nav/SideBar.svelte
+++ b/frontend/src/routes/editor/nav/SideBar.svelte
@@ -97,7 +97,9 @@
 	}
 
 	.directory-nav {
-		margin-top: 2rem;
+		margin-top: 1rem;
+		margin-left: 0.25rem;
+		margin-right: calc(0.5rem - 3px);
 		overflow-x: hidden;
 		/* overflow-y: scroll; */
 	}


### PR DESCRIPTION
Fixes #2 

This *will* screw up the rendering if the Markdown file isn't formatted correctly, as it's a bruteforce way to remove it, but this is an extreme edge case that we probably won't fix.

![image](https://github.com/r-Techsupport/hyde/assets/105120272/7e8fb4fe-f267-4696-a3e7-ef25b754656a)