### PR TITLE
75 auto validate and merge patch level dependabot updates

### DIFF
--- a/.github/workflows/build-push-amd64.yml
+++ b/.github/workflows/build-push-amd64.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - devel
   workflow_dispatch:
   schedule:
     - cron: "0 13 * * *"
@@ -17,10 +16,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: 
-          - main
     permissions:
       contents: write
       packages: write
@@ -29,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -53,7 +46,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}
           flavor: latest=auto
           tags: |
-            type=raw,value={{branch}}
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            type=raw,value=devel,enable=${{ github.ref != format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
@@ -76,8 +70,8 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ matrix.branch }}
-          artifact-name: ${{ env.IMAGE }}-${{ matrix.branch }}.spdx
+          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ github.sha }}
+          artifact-name: ${{ env.IMAGE }}-${{ github.sha }}.spdx
           format: spdx-json
           upload-artifact: true
           upload-artifact-retention: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
-    GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   # This should depend on the backend and frontend builds, then if it is a PR submitted by Dependabot that is a patch it will merge the PR
   close_pr:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Merge PR
-        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
 
   # This should depend on the backend and frontend builds, then if it is a PR submitted by Dependabot that is a patch it will merge the PR
   close_pr:
-    needs: backend-build && frontend-build
+    needs: 
+      - backend-build
+      - frontend-build
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,22 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
+    GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  # This should depend on the backend and frontend builds, then if it is a PR submitted by Dependabot that is a patch it will merge the PR
+  close_pr:
+    needs: backend-build && frontend-build
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Merge PR
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This should cleanup my first container CI by removing the Devel idea, something I did on nginx-certbot earlier today without issue

This also introduces a conditional block into ci.yml that depends on both the front and backend builds. It will merge a PR if made by Dependabot and only if it is semantically a patch