### PR TITLE
PR #232 fixes

### DIFF
--- a/backend/src/app_conf.rs
+++ b/backend/src/app_conf.rs
@@ -1,8 +1,9 @@
-use std::fs;
+use std::{fs, process};
 use std::sync::Arc;
 use serde::Deserialize;
+use tracing::{info, error};
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct AppConf {
     pub files: Files,
     pub discord: Discord,
@@ -10,25 +11,25 @@ pub struct AppConf {
     pub database: Database,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Files {
     pub asset_path: String,
     pub docs_path: String,
     pub repo_url: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Discord {
     pub admin_username: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct OAuth {
     pub discord: DiscordOAuth,
     pub github: GitHubOAuth,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct DiscordOAuth {
     pub client_id: String,
     pub secret: String,
@@ -36,23 +37,74 @@ pub struct DiscordOAuth {
     pub token_url: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct GitHubOAuth {
     pub client_id: String,
     // Uncomment this if needed
     // pub secret: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Database {
     pub url: String,
 }
 
+// Trait to validate fields in each struct
+trait ValidateFields {
+    fn validate(&self, path: &str) -> Result<(), String>;
+}
+
+// Macro to validate all fields for each struct
+macro_rules! impl_validate {
+    ($struct_name:ident, $( $field:ident ),* ) => {
+        impl ValidateFields for $struct_name {
+            fn validate(&self, path: &str) -> Result<(), String> {
+                $(
+                    let field_path = format!("{}.{}", path, stringify!($field));
+                    if self.$field.is_empty() {
+                        return Err(format!("Field '{}' is empty", field_path));
+                    }
+                )*
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_validate!(Files, asset_path, docs_path, repo_url);
+impl_validate!(Discord, admin_username);
+impl_validate!(DiscordOAuth, client_id, secret, url, token_url);
+impl_validate!(GitHubOAuth, client_id);
+impl_validate!(Database, url);
+
+impl ValidateFields for OAuth {
+    fn validate(&self, path: &str) -> Result<(), String> {
+        self.discord.validate(&format!("{}.discord", path))?;
+        self.github.validate(&format!("{}.github", path))?;
+        Ok(())
+    }
+}
+
+impl ValidateFields for AppConf {
+    fn validate(&self, path: &str) -> Result<(), String> {
+        self.files.validate(&format!("{}.files", path))?;
+        self.discord.validate(&format!("{}.discord", path))?;
+        self.oauth.validate(&format!("{}.oauth", path))?;
+        self.database.validate(&format!("{}.database", path))?;
+        Ok(())
+    }
+}
 impl AppConf {
     pub fn load() -> Arc<Self> {
         let file = fs::read_to_string("default.toml").expect("Unable to read config");
         let config: Self = toml::from_str(&file).expect("Unable to parse config");
-        
+        match config.validate("config") {
+            Ok(_) => info!("Configuration isn't empty"),
+            Err(e) => {
+                error!("Validation error: {}", e);
+                process::exit(1)
+            },
+        }
         Arc::new(config)
     }
 }

--- a/backend/src/app_conf.rs
+++ b/backend/src/app_conf.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::process::exit;
 use std::sync::Arc;
 use serde::Deserialize;
-use tracing::{info, error, debug, trace};
+use tracing::{info, error, trace};
 
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct AppConf {

--- a/backend/src/app_conf.rs
+++ b/backend/src/app_conf.rs
@@ -15,6 +15,7 @@ pub struct AppConf {
 pub struct Files {
     pub asset_path: String,
     pub docs_path: String,
+    pub repo_path: String,
     pub repo_url: String,
 }
 
@@ -71,7 +72,7 @@ macro_rules! impl_validate {
     };
 }
 
-impl_validate!(Files, asset_path, docs_path, repo_url);
+impl_validate!(Files, asset_path, docs_path, repo_path, repo_url);
 impl_validate!(Discord, admin_username);
 impl_validate!(DiscordOAuth, client_id, secret, url, token_url);
 impl_validate!(GitHubOAuth, client_id);

--- a/backend/src/handlers_prelude/doc.rs
+++ b/backend/src/handlers_prelude/doc.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use axum::{debug_handler, extract::{Query, State}, http::{HeaderMap, StatusCode}, Json, Router};
 use axum::routing::get;
 use serde::{Deserialize, Serialize};
@@ -83,7 +82,7 @@ pub async fn put_doc_handler(
 
     match state
         .git
-        .put_doc(Arc::clone(&state.config), &body.path, &body.contents, &final_commit_message, &gh_token)
+        .put_doc(&state.config.files.repo_url, &body.path, &body.contents, &final_commit_message, &gh_token)
     {
         Ok(_) => Ok(StatusCode::CREATED),
         Err(e) => {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,8 +26,7 @@ use db::Database;
 use gh::GithubAccessToken;
 use handlers_prelude::*;
 #[cfg(target_family = "unix")]
-use tracing::error;
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, info, info_span, warn, error};
 // use tracing_subscriber::filter::LevelFilter;
 use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, TokenUrl};
 use reqwest::{

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -129,8 +129,7 @@ async fn main() -> Result<()> {
 #[tracing::instrument]
 async fn init_state(cli_args: &Args) -> Result<AppState> {
     let config: Arc<AppConf> = AppConf::load(&cli_args.cfg);
-
-
+    
     let repo_url = config.files.repo_url.clone();
     let repo_path = config.files.repo_path.clone();
     let docs_path = config.files.docs_path.clone();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -134,11 +134,14 @@ async fn main() -> Result<()> {
 #[tracing::instrument]
 async fn init_state() -> Result<AppState> {
     let config = AppConf::load();
+
     let repo_url = config.files.repo_url.clone();
-    let git = task::spawn(async { git::Interface::new(repo_url)}).await??;
+    let repo_path = config.files.repo_path.clone();
+    let docs_path = config.files.docs_path.clone();
+    
+    let git = task::spawn(async { git::Interface::new(repo_url, repo_path, docs_path)}).await??;
     let reqwest_client = Client::new();
     
-    // We have to clone here, since the client will need to keep the values from the config.
     let oauth = BasicClient::new(
         ClientId::new(config.oauth.discord.client_id.clone()),
         Some(ClientSecret::new(config.oauth.discord.secret.clone())),

--- a/default.toml
+++ b/default.toml
@@ -4,8 +4,11 @@
 asset_path = "docs/"
 # The location of the assets files relative to the root of the repo
 docs_path = "assets/"
+# The path where the repository will be pulled and used
+repo_path = "repo/"
 # The URL of the jekyll repository to interface with
 repo_url = "https://github.com/r-Techsupport/rTS_Wiki.git"
+
 
 # Discord is related to discord specific information to pass to Hyde.
 [discord]


### PR DESCRIPTION
This PR fixes the issues from #232 

**Fixes:**
- Remove AppConf passed directly to non-handler functions
- Fix function parameters that use AppConfig directly, instead pass actual value references
- Fix `docs_path.push()` inside `git::new`
- Fix complexity inside `app_conf` `load()` function

**Additions:**
- Add `repo_path` as an option for the possibility to relocate where the repo resides