### PR TITLE
407 devel env

### DIFF
--- a/.github/workflows/container-aca-devel.yml
+++ b/.github/workflows/container-aca-devel.yml
@@ -1,0 +1,103 @@
+name: Build image and push to ACA
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPO: r-techsupport
+  IMAGE: hyde
+
+jobs:
+  image-builder:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          context: git
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}
+          flavor: latest=auto
+          tags: |
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            type=raw,value=devel,enable=true
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Containerfile
+
+  sbom-attestation:
+    runs-on: ubuntu-latest
+    needs: image-builder
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}
+          subject-digest: ${{ needs.image-builder.outputs.digest }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ github.sha }}
+          artifact-name: ${{ env.IMAGE }}-${{ github.sha }}.spdx
+          format: spdx-json
+          upload-artifact: true
+          upload-artifact-retention: 7
+
+  deploy-aca:
+      runs-on: ubuntu-latest
+      needs: image-builder
+      env:
+        RESOURCE_GROUP: hyde-dev-group
+        CONTAINER_APP: hyde-dev-container
+
+      steps:
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Copy revision
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.61.0
+          inlineScript: |
+            az containerapp revision copy -n ${{ env.CONTAINER_APP }} -g ${{ env.RESOURCE_GROUP }} \
+              --image ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ github.sha }} \
+              --revision-suffix gha-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/container-aca-latest.yml
+++ b/.github/workflows/container-aca-latest.yml
@@ -44,8 +44,7 @@ jobs:
           flavor: latest=auto
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
-            type=raw,value=devel,enable=${{ github.ref != format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=true
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
This creates a new GHA for `devel` and renames the existing to `latest` to keep a uniform naming scheme. 

Creating the new devel GHA instead of appending to the current was done to avoid complex IF logic. 

The original `latest` GHA was simplified so it will always created the `latest` tag on any Git tag that gets pushed. 

The `devel` GHA builds on any push to master.

Both use the commit SHA as well, this may cause a conflict so that needs to be tested.

Please hold off merging, I am still working on the Azure side. 