### PR TITLE
Split commit functions

### DIFF
--- a/backend/src/handlers_prelude/mod.rs
+++ b/backend/src/handlers_prelude/mod.rs
@@ -55,6 +55,12 @@ impl From<String> for ApiError {
     }
 }
 
+impl From<(StatusCode, String)> for ApiError {
+    fn from((_, msg): (StatusCode, String)) -> Self {
+        Self(eyre::eyre!(msg))
+    }
+}
+
 /// Quick and dirty way to convert an eyre error to a (StatusCode, message) response, meant for use with `map_err`, so that errors can be propagated out of
 /// axum handlers with `?`.
 pub fn eyre_to_axum_err(e: Report) -> (StatusCode, String) {


### PR DESCRIPTION
Small refactor of the doc/assets functions were removing the git functions and adding them to the handlers.