### PR TITLE
Fix reclone on Windows

### DIFF
--- a/backend/src/git.rs
+++ b/backend/src/git.rs
@@ -253,7 +253,7 @@ impl Interface {
         Repository::clone(&self.repo_url, tmp_repo_path)?;
 
         // Make a dummy repo and replace the old repo in the mutex with it
-        let dummy_repo = Repository::init("./dummy")?;
+        let dummy_repo = Repository::init("./dummy__tmp")?;
         let mut lock = self.repo.lock().unwrap();
         *lock = dummy_repo;
 
@@ -264,7 +264,7 @@ impl Interface {
         // Now, replace the dummy in the mutex with the new clone and cleanup
         let new_repo = Repository::open(repo_path)?;
         *lock = new_repo;
-        fs::remove_dir_all("./dummy")?;
+        fs::remove_dir_all("./dummy__tmp")?;
         drop(lock);
 
         info!("Reclone completed successfully");

--- a/backend/src/git.rs
+++ b/backend/src/git.rs
@@ -242,21 +242,32 @@ impl Interface {
     pub fn reclone(&self) -> Result<()> {
         // First clone a repo into `repo__tmp`, open that, swap out
         let repo_path = Path::new("./repo"); // TODO: Possibly implement this path into new config?
-        let tmp_path = Path::new("./repo__tmp");
+        let tmp_repo_path = Path::new("./repo__tmp");
 
         // if a reclone was attempted but failed, repo__tmp might still exist
-        if tmp_path.exists() {
+        if tmp_repo_path.exists() {
             warn!("A previous re-clone failed, stale data was found");
-            remove_dir_all(tmp_path)?;
+            remove_dir_all(tmp_repo_path)?;
         }
-        let tmp_repo = Repository::clone(&self.repo_url, tmp_path)?;
 
+        // clone into tmp directory
+        Repository::clone(&self.repo_url, tmp_repo_path)?;
+
+        // make a dummy repo and replace the one in the mutex with it
+        let dummy_repo = Repository::init("./dummy")?;
         let mut lock = self.repo.lock().unwrap();
-        *lock = tmp_repo;
+        *lock = dummy_repo;
+
         info!("Deleting the old repo and replacing it with the new one...");
         fs::remove_dir_all(repo_path)?;
-        fs::rename(tmp_path, repo_path)?;
-        *lock = Repository::open(repo_path)?;
+        fs::rename(tmp_repo_path, repo_path)?;
+
+        // now, replace the dummy in the mutex with the new clone
+        let new_repo = Repository::open(repo_path)?;
+        *lock = new_repo;
+
+        // cleanup
+        fs::remove_dir_all("./dummy")?;
         drop(lock);
         Ok(())
     }

--- a/backend/src/git.rs
+++ b/backend/src/git.rs
@@ -240,35 +240,34 @@ impl Interface {
     /// Completely clone and open a new repository, deleting the old one.
     #[tracing::instrument(skip_all)]
     pub fn reclone(&self) -> Result<()> {
-        // First clone a repo into `repo__tmp`, open that, swap out
         let repo_path = Path::new("./repo"); // TODO: Possibly implement this path into new config?
         let tmp_repo_path = Path::new("./repo__tmp");
 
-        // if a reclone was attempted but failed, repo__tmp might still exist
+        // If a reclone was attempted but failed, repo__tmp might still exist
         if tmp_repo_path.exists() {
-            warn!("A previous re-clone failed, stale data was found");
+            warn!("A previous re-clone failed, removing stale data...");
             remove_dir_all(tmp_repo_path)?;
         }
 
-        // clone into tmp directory
+        // Clone the repo into tmp directory
         Repository::clone(&self.repo_url, tmp_repo_path)?;
 
-        // make a dummy repo and replace the one in the mutex with it
+        // Make a dummy repo and replace the old repo in the mutex with it
         let dummy_repo = Repository::init("./dummy")?;
         let mut lock = self.repo.lock().unwrap();
         *lock = dummy_repo;
 
-        info!("Deleting the old repo and replacing it with the new one...");
+        debug!("Deleting the old repo and replacing it with the new one...");
         fs::remove_dir_all(repo_path)?;
         fs::rename(tmp_repo_path, repo_path)?;
 
-        // now, replace the dummy in the mutex with the new clone
+        // Now, replace the dummy in the mutex with the new clone and cleanup
         let new_repo = Repository::open(repo_path)?;
         *lock = new_repo;
-
-        // cleanup
         fs::remove_dir_all("./dummy")?;
         drop(lock);
+
+        info!("Reclone completed successfully");
         Ok(())
     }
 


### PR DESCRIPTION
The reclone function fails on Windows with an access denied error when it tries to rename the "repo__tmp" directory to "repo". This is presumably because `git2::Repository` holds a handle to the repo directory, which makes the rename fail.

This change fixes the issue by only cloning the repo without holding an instance of it, then performing the rest of the procedure.