### PR TITLE
frontend: Force vite port 5173 in dev environment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,5 +2,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		port: 5173,
+		strictPort: true
+	}
 });


### PR DESCRIPTION
Makes vite strictly use port 5173 since the backend assumes the frontend is always at 5173 in development mode.

Closes #313 