### PR TITLE
frontend: Handle same name asset uploads

### DIFF
--- a/frontend/src/lib/components/editors/AssetEditor.svelte
+++ b/frontend/src/lib/components/editors/AssetEditor.svelte
@@ -15,6 +15,7 @@
 	let uploadedFiles: FileList | undefined = $state();
 
 	async function putFile(file: File) {
+		loadingIconVisible = true;
 		const r = await fetch(`${apiAddress}/api/asset/${assetFolderPath}/${file.name}`, {
 			method: 'PUT',
 			credentials: 'include',
@@ -25,6 +26,7 @@
 		assetTree.name = reportedTree.name;
 		assetTree.children = reportedTree.children;
 
+		loadingIconVisible = false;
 		if (r.ok) {
 			addToast(`"${file.name}" was uploaded successfully`, ToastType.Info, true, 1500);
 		} else {

--- a/frontend/src/lib/components/editors/AssetEditor.svelte
+++ b/frontend/src/lib/components/editors/AssetEditor.svelte
@@ -13,29 +13,42 @@
 	let { assetFolderPath = $bindable('') }: Props = $props();
 	let uploadedFiles: FileList | undefined = $state();
 
+	async function putFile(file: File) {
+		const r = await fetch(`${apiAddress}/api/asset/${assetFolderPath}/${file.name}`, {
+			method: 'PUT',
+			credentials: 'include',
+			headers: { 'Content-Type': 'application/octet-stream' },
+			body: await file.arrayBuffer()
+		});
+		const reportedTree = await (await fetch(`${apiAddress}/api/tree/asset`)).json();
+		assetTree.name = reportedTree.name;
+
+		if (r.ok) {
+			addToast(`"${file.name}" was uploaded successfully`, ToastType.Info, true, 1500);
+		} else {
+			addToast(
+				`Failed to upload file, please report issue to the developer`,
+				ToastType.Error,
+				true,
+				1500
+			);
+		}
+	}
+
 	async function fileUploadHandler() {
 		if (uploadedFiles && uploadedFiles.length > 0) {
 			loadingIconVisible = true;
 			const file = uploadedFiles.item(0)!;
-			const r = await fetch(`${apiAddress}/api/asset/${assetFolderPath}/${file.name}`, {
-				method: 'PUT',
-				credentials: 'include',
-				headers: { 'Content-Type': 'application/octet-stream' },
-				body: await file.arrayBuffer()
-			});
-			const reportedTree = await (await fetch(`${apiAddress}/api/tree/asset`)).json();
-			assetTree.name = reportedTree.name;
-
-			loadingIconVisible = false;
-			if (r.ok) {
-				addToast(`"${file.name}" was uploaded successfully`, ToastType.Info, true, 1500);
+			if (
+				assetTree.children
+					.find((n) => n.name === assetFolderPath)
+					?.children.find((f) => f.name === file.name)
+			) {
+				loadingIconVisible = false;
+				replaceConfirmationVisible = true;
 			} else {
-				addToast(
-					`Failed to upload file, please report issue to the developer`,
-					ToastType.Error,
-					true,
-					1500
-				);
+				await putFile(file);
+				loadingIconVisible = false;
 			}
 		}
 	}
@@ -67,6 +80,7 @@
 	});
 
 	let deletionConfirmationVisible = $state(false);
+	let replaceConfirmationVisible = $state(false);
 	let loadingIconVisible = $state(false);
 	// Whenever the list of uploaded files changes, call the handler to write new changes
 	// to the git repo
@@ -221,6 +235,23 @@
 			<code>Upload new asset</code>
 		</label>
 	</div>
+	{#if replaceConfirmationVisible}
+		<ConfirmationDialogue
+			bind:visible={replaceConfirmationVisible}
+			confirmText="Replace"
+			confirmHandler={() => {
+				putFile(uploadedFiles!.item(0)!);
+			}}
+			cancelText="Cancel"
+			cancelHandler={() => {
+				uploadedFiles;
+				replaceConfirmationVisible = false;
+			}}
+		>
+			File <strong><code>{uploadedFiles!.item(0)!.name}</code></strong> already exists. <br />
+			Do you want to replace it with the uploaded file?
+		</ConfirmationDialogue>
+	{/if}
 {:else}
 	<p class="noasset-placeholder">
 		No folder selected, please select a folder to start managing assets.

--- a/frontend/src/lib/components/editors/AssetEditor.svelte
+++ b/frontend/src/lib/components/editors/AssetEditor.svelte
@@ -11,6 +11,7 @@
 	}
 
 	let { assetFolderPath = $bindable('') }: Props = $props();
+	let fileInput: HTMLInputElement | undefined = $state();
 	let uploadedFiles: FileList | undefined = $state();
 
 	async function putFile(file: File) {
@@ -82,13 +83,6 @@
 	let deletionConfirmationVisible = $state(false);
 	let replaceConfirmationVisible = $state(false);
 	let loadingIconVisible = $state(false);
-	// Whenever the list of uploaded files changes, call the handler to write new changes
-	// to the git repo
-	$effect(() => {
-		// eslint-disable-next-line
-		uploadedFiles;
-		fileUploadHandler();
-	});
 	$effect(() => {
 		if (fullScreenImagePath !== '') {
 			fetch(`${apiAddress}/api/asset/${fullScreenImagePath}`).then(async (r) => {
@@ -227,7 +221,18 @@
 				<code>{asset.name}</code>
 			</button>
 		{/each}
-		<input bind:files={uploadedFiles} type="file" id="upload-new" style="display: none" />
+		<input
+			bind:this={fileInput}
+			bind:files={uploadedFiles}
+			onchange={fileUploadHandler}
+			onclick={() => {
+				fileInput!.value = '';
+				uploadedFiles = undefined;
+			}}
+			type="file"
+			id="upload-new"
+			style="display: none"
+		/>
 		<label for="upload-new" class="asset upload-new" title="Upload new asset">
 			<svg xmlns="http://www.w3.org/2000/svg" height="80%" viewBox="0 -960 960 960" width="80%"
 				><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z" /></svg
@@ -244,7 +249,6 @@
 			}}
 			cancelText="Cancel"
 			cancelHandler={() => {
-				uploadedFiles;
 				replaceConfirmationVisible = false;
 			}}
 		>

--- a/frontend/src/lib/components/editors/AssetEditor.svelte
+++ b/frontend/src/lib/components/editors/AssetEditor.svelte
@@ -23,6 +23,7 @@
 		});
 		const reportedTree = await (await fetch(`${apiAddress}/api/tree/asset`)).json();
 		assetTree.name = reportedTree.name;
+		assetTree.children = reportedTree.children;
 
 		if (r.ok) {
 			addToast(`"${file.name}" was uploaded successfully`, ToastType.Info, true, 1500);

--- a/frontend/src/lib/components/editors/DocumentEditor.svelte
+++ b/frontend/src/lib/components/editors/DocumentEditor.svelte
@@ -54,6 +54,7 @@
 			return;
 		}
 
+		commitMessageInput = "";
 		showCommitModal = false;
 		await saveChangesHandler(commitMessage);
 	}

--- a/frontend/src/lib/components/editors/DocumentEditor.svelte
+++ b/frontend/src/lib/components/editors/DocumentEditor.svelte
@@ -54,7 +54,7 @@
 			return;
 		}
 
-		commitMessageInput = "";
+		commitMessageInput = '';
 		showCommitModal = false;
 		await saveChangesHandler(commitMessage);
 	}


### PR DESCRIPTION
* Add a replace confirmation dialog when uploading an asset with a name that already exists in the selected asset folder (Closes #454). Also, an uploaded asset is now immediately shown in the frontend instead of needing a page refresh.
* Clear commit message box when change is committed (Closes #248).