### PR TITLE
Add Docker and GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker" # Contains support for "Containerfile" naming scheme
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds the Docker ecosystem (which has support for "Containerfile") and Github-Actions ecosystem, both are watching "/" for changes which should not cause issues. 

All update actions in this repo pull all updates found, this can be restricted by Semver if we desire. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#allow-- 

How Dependabot will handle the complexity of our tags like "rust:1.96-alpine3.24" is unknown but I am confident that it is smart enough to at least try it unrestrained, brief research says it is smart enough to not jump to ":latest" at the very least. 