### PR TITLE
ci: run full CI when .github changes

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "main" ]
     paths:
       - backend/**
+      - .github/**
   pull_request:
     branches: [ "main" ]
     paths:
       - backend/**
+      - .github/**
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,10 +8,12 @@ on:
     branches: [ "main" ]
     paths:
       - frontend/**
+      - .github/**
   pull_request:
     branches: [ "main" ]
     paths:
       - frontend/**
+      - .github/**
 
 jobs:
   frontend-build:


### PR DESCRIPTION
When Dependabot updates container versions for Github actions, no CI runs.

This change runs full CI when any file in `.github/` changes.