### PR TITLE
fix: filenav now more reliably reports the path it's looking at

### DIFF
--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -21,10 +21,6 @@ class DocumentCache {
 	 * @param path The path of the asset to fetch
 	 */
 	public async get(path: string): Promise<CacheEntry | null> {
-		// Stupid hack fix because I don't want to do a real fix
-		if (path.startsWith('docs')) {
-			path = path.replace('docs', '');
-		}
 		const hasKey = this.values.has(path);
 		let entry: CacheEntry;
 		// Re-insert to mark it as most recently accessed

--- a/frontend/src/lib/components/sidebar/FileNavigation.svelte
+++ b/frontend/src/lib/components/sidebar/FileNavigation.svelte
@@ -233,7 +233,7 @@ last_modified_date: ${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}
 				children={child.children}
 				siblings={children}
 				indent={indent + 1.5}
-				path={path + child.name}
+				path={path === 'docs' ? child.name : path + child.name}
 				{fileSelectHandler}
 			/>
 		{:else}
@@ -243,7 +243,7 @@ last_modified_date: ${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}
 				children={child.children}
 				siblings={children}
 				indent={indent + 1}
-				path={path + child.name + '/'}
+				path={path === 'docs' ? child.name + '/' : path + child.name + '/'}
 				{fileSelectHandler}
 			/>
 		{/if}


### PR DESCRIPTION
While still not an ideal solution, this is more robust than it was before, so we'll consider it a success.